### PR TITLE
Fix #19, overloaded build flags

### DIFF
--- a/mussels/__main__.py
+++ b/mussels/__main__.py
@@ -253,8 +253,8 @@ def recipe_clone(recipe: str, version: str, cookbook: str, dest: str):
     help="Print out the version dependency graph without actually doing a build. [optional]",
 )
 @click.option(
-    "--clean",
-    "-c",
+    "--rebuild",
+    "-r",
     is_flag=True,
     help="Re-build a recipe, even if already built. [optional]",
 )
@@ -267,7 +267,7 @@ def recipe_build(
     cookbook: str,
     target: str,
     dry_run: bool,
-    clean: bool,
+    rebuild: bool,
     install: str,
 ):
     """
@@ -279,7 +279,7 @@ def recipe_build(
     results = []
 
     success = my_mussels.build_recipe(
-        recipe, version, cookbook, target, results, dry_run, clean
+        recipe, version, cookbook, target, results, dry_run, rebuild
     )
     if success == False:
         sys.exit(1)
@@ -447,8 +447,8 @@ def clean_all():
     help="Print out the version dependency graph without actually doing a build. [optional]",
 )
 @click.option(
-    "--clean",
-    "-c",
+    "--rebuild",
+    "-r",
     is_flag=True,
     help="Re-build a recipe, even if already built. [optional]",
 )
@@ -463,7 +463,7 @@ def build_alias(
     cookbook: str,
     target: str,
     dry_run: bool,
-    clean: bool,
+    rebuild: bool,
     install: str,
 ):
     """


### PR DESCRIPTION
The `msl build -c` was used for both --cookbook and --clean, which broke
the ability to build from a specific cookbook.

Reanamed the --clean option to --rebuild with -r shorthand to fix the
isssue.