### PR TITLE
Fix #20, overzealous tool version pruning

### DIFF
--- a/mussels/tool.py
+++ b/mussels/tool.py
@@ -109,12 +109,12 @@ class BaseTool(object):
 
             process.wait()
             if process.returncode != 0:
-                self.logger.warning(f"Command failed!")
+                self.logger.debug(f"Command failed!")
                 return False
         except FileNotFoundError:
-            self.logger.warning(f"Command failed; File not found!")
+            self.logger.debug(f"Command failed; File not found!")
             return False
-            
+
         return found_expected_output
 
     def detect(self) -> bool:
@@ -174,7 +174,7 @@ class BaseTool(object):
                 break
 
         if not found:
-            self.logger.warning(f"Failed to detect {self.name_version}.")
+            self.logger.debug(f"Failed to detect {self.name_version}.")
             return False
 
         return True


### PR DESCRIPTION
The _get_recipe_version() method was supposed to select a recipe
version, and then prune the list of available tools based on any
restrictions listed in the recipe.  Instead, it was pruning the list of
available tools based on any restrictions listed in ALL recipes, which
naturally caused problems once recipes were added that have
non-overlapping tool version requiirements.

This patch fixes this pruning behavior and also adds much needed debug
log output when pruning occurs and much easier to read error output in
the event that suitable tool versions cannot be found.