### PR TITLE
Address #18, build with custom work director

### DIFF
--- a/mussels/__main__.py
+++ b/mussels/__main__.py
@@ -259,7 +259,16 @@ def recipe_clone(recipe: str, version: str, cookbook: str, dest: str):
     help="Re-build a recipe, even if already built. [optional]",
 )
 @click.option(
-    "--install", "-i", default="", help="Specific install directory. [optional]"
+    "--install", "-i", default="", help="Install directory. [optional] Default is: ~/.mussels/install/<target>"
+)
+@click.option(
+    "--work-dir", "-w", default="", help="Work directory. [optional] Default is: ~/.mussels/cache/work"
+)
+@click.option(
+    "--log-dir", "-l", default="", help="Log directory. [optional] Default is: ~/.mussels/logs"
+)
+@click.option(
+    "--download-dir", "-D", default="", help="Downloads directory. [optional] Default is: ~/.mussels/cache/downloads"
 )
 def recipe_build(
     recipe: str,
@@ -269,12 +278,20 @@ def recipe_build(
     dry_run: bool,
     clean: bool,
     install: str,
+    work_dir: str,
+    log_dir: str,
+    download_dir: str,
 ):
     """
     Download, extract, build, and install a recipe.
     """
 
-    my_mussels = Mussels(install_dir=install)
+    my_mussels = Mussels(
+        install_dir=install,
+        work_dir=work_dir,
+        log_dir=log_dir,
+        download_dir=download_dir,
+    )
 
     results = []
 
@@ -453,7 +470,16 @@ def clean_all():
     help="Re-build a recipe, even if already built. [optional]",
 )
 @click.option(
-    "--install", "-i", default="", help="Specific install directory. [optional]"
+    "--install", "-i", default="", help="Install directory. [optional] Default is: ~/.mussels/install/<target>"
+)
+@click.option(
+    "--work-dir", "-w", default="", help="Work directory. [optional] Default is: ~/.mussels/cache/work"
+)
+@click.option(
+    "--log-dir", "-l", default="", help="Log directory. [optional] Default is: ~/.mussels/logs"
+)
+@click.option(
+    "--download-dir", "-D", default="", help="Downloads directory. [optional] Default is: ~/.mussels/cache/downloads"
 )
 @click.pass_context
 def build_alias(
@@ -465,6 +491,9 @@ def build_alias(
     dry_run: bool,
     clean: bool,
     install: str,
+    work_dir: str,
+    log_dir: str,
+    download_dir: str,
 ):
     """
     Download, extract, build, and install a recipe.

--- a/mussels/mussels.py
+++ b/mussels/mussels.py
@@ -71,10 +71,10 @@ class Mussels:
         self,
         load_all_recipes: bool = False,
         data_dir: str = os.path.join(str(Path.home()), ".mussels"),
-        log_file: str = os.path.join(
-            str(Path.home()), ".mussels", "logs", "mussels.log"
-        ),
         install_dir: str = "",
+        work_dir: str = "",
+        log_dir: str = "",
+        download_dir: str = "",
         log_level: str = "DEBUG",
     ) -> None:
         """
@@ -85,7 +85,10 @@ class Mussels:
             log_file:   path output log.
             log_level:  log level ("DEBUG", "INFO", "WARNING", "ERROR").
         """
-        self.log_file = log_file
+        if log_dir != "":
+            self.log_file = os.path.join(log_dir, "mussels.log")
+        else:
+            self.log_file = os.path.join(data_dir, "logs", "mussels.log")
         self._init_logging(log_level)
 
         self.app_data_dir = data_dir
@@ -95,6 +98,10 @@ class Mussels:
         else:
             self.install_dir = os.path.abspath(install_dir)
             self.custom_install_dir = True
+
+        self.work_dir = "" if work_dir == "" else os.path.abspath(work_dir)
+        self.log_dir = "" if log_dir == "" else os.path.abspath(log_dir)
+        self.download_dir = "" if download_dir == "" else os.path.abspath(download_dir)
 
         self._load_config("cookbooks.json", self.cookbooks)
         self._load_recipes(all=load_all_recipes)
@@ -546,6 +553,9 @@ class Mussels:
             target=target,
             data_dir=self.app_data_dir,
             install_dir=install_dir,
+            work_dir=self.work_dir,
+            log_dir=self.log_dir,
+            download_dir=self.download_dir,
         )
 
         if not recipe_object._build(clean):

--- a/mussels/recipe.py
+++ b/mussels/recipe.py
@@ -77,6 +77,9 @@ class BaseRecipe(object):
         target: str,
         install_dir: str = "",
         data_dir: str = "",
+        work_dir: str = "",
+        log_dir: str = "",
+        download_dir: str = "",
     ):
         """
         Download the archive (if necessary) to the Downloads directory.
@@ -93,9 +96,21 @@ class BaseRecipe(object):
             self.data_dir = os.path.abspath(data_dir)
 
         self.install_dir = install_dir
-        self.downloads_dir = os.path.join(self.data_dir, "cache", "downloads")
-        self.logs_dir = os.path.join(self.data_dir, "logs", "recipes")
-        self.work_dir = os.path.join(self.data_dir, "cache", "work")
+
+        if download_dir != "":
+            self.download_dir = download_dir
+        else:
+            self.download_dir = os.path.join(self.data_dir, "cache", "downloads")
+
+        if log_dir != "":
+            self.log_dir = log_dir
+        else:
+            self.log_dir = os.path.join(self.data_dir, "logs", "recipes")
+
+        if work_dir != "":
+            self.work_dir = work_dir
+        else:
+            self.work_dir = os.path.join(self.data_dir, "cache", "work")
 
         self.module_dir = os.path.split(self.module_file)[0]
 
@@ -112,7 +127,7 @@ class BaseRecipe(object):
         """
         Initializes the logging parameters
         """
-        os.makedirs(self.logs_dir, exist_ok=True)
+        os.makedirs(self.log_dir, exist_ok=True)
 
         self.logger = logging.getLogger(f"{nvc_str(self.name, self.version)}")
         self.logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
@@ -123,7 +138,7 @@ class BaseRecipe(object):
         )
 
         self.log_file = os.path.join(
-            self.logs_dir,
+            self.log_dir,
             f"{nvc_str(self.name, self.version)}.{datetime.datetime.now()}.log".replace(
                 ":", "_"
             ),
@@ -138,7 +153,7 @@ class BaseRecipe(object):
         """
         Use the URL to download the archive if it doesn't already exist in the Downloads directory.
         """
-        os.makedirs(self.downloads_dir, exist_ok=True)
+        os.makedirs(self.download_dir, exist_ok=True)
 
         # Determine download path from URL &  possible archive name change.
         self.archive = self.url.split("/")[-1]
@@ -147,7 +162,7 @@ class BaseRecipe(object):
                 self.archive_name_change[0], self.archive_name_change[1]
             )
         self.download_path = os.path.join(
-            self.data_dir, "cache", "downloads", self.archive
+            self.download_dir, self.archive
         )
 
         # Exit early if we already have the archive.


### PR DESCRIPTION
A user may wish to build with a custom work directory. It may even be
necessary if running concurrent build commands.

This commit adds the `msl build --work` flag (`-w` shorthand) to allow
users to specify a unique work location for the build. Logs and other
cache files will still be written to the ~/.mussels/cache directory.