### PR TITLE
Add tool variables for use in recipe scripts

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,10 @@
 name: Unit Tests
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:
@@ -26,4 +30,4 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest
-          pytest
+          pytest -vvs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,63 @@ Changes in this document should be grouped per release using the following types
 - Fixed
 - Security
 
+## Version 0.3.0
+
+### Added
+
+- Added the ability to define variables in tools that can be accessed in recipes.
+
+  To define variables, add a `variables` list for each platform.
+
+  This feature was inspired by a need to make recipes that have strings in them specific to a given tool version. Specifically we'll be using this to define CMake generator names in Visual Studio tool YAML files. The correct generator name for a given Visual Studio version will then be available for use in recipes that use Visual Studio.
+
+  Example tool, `visualstudio-2017.yaml`:
+
+  ```yaml
+  name: visualstudio
+  version: "2017"
+  mussels_version: "0.3"
+  type: tool
+  platforms:
+    Windows:
+      file_checks:
+        - C:\/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Auxiliary/Build/vcvarsall.bat
+        - C:\/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvarsall.bat
+        - C:\/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvarsall.bat
+      variables:
+        cmake_generator: Visual Studio 15 2017
+  ```
+
+  Example recipe, `libz.yaml`:
+
+  ```yaml
+  name: libz
+  version: "1.2.11"
+  url: https://www.zlib.net/zlib-1.2.11.tar.gz
+  mussels_version: "0.3"
+  type: recipe
+  platforms:
+    Windows:
+      x64:
+        build_script:
+          configure: |
+            CALL cmake.exe -G "{visualstudio.cmake_generator} Win64"
+          make: |
+            CALL cmake.exe --build . --config Release
+        dependencies: []
+        install_paths:
+          include:
+            - zlib.h
+            - zconf.h
+          lib:
+            - Release/zlibstatic.lib
+          license/zlib:
+            - README
+        required_tools:
+          - cmake
+          - visualstudio>=2017
+  ```
+
 ## Version 0.2.1
 
 ### Added

--- a/mussels/tool.py
+++ b/mussels/tool.py
@@ -51,7 +51,10 @@ class BaseTool(object):
     logs_dir = ""
     tool_path = ""
 
-    def __init__(self, data_dir: str = ""):
+    def __init__(self,
+        data_dir: str = "",
+        log_level: str = "DEBUG",
+    ):
         """
         Download the archive (if necessary) to the Downloads directory.
         Extract the archive to the temp directory so it is ready to build.
@@ -65,14 +68,21 @@ class BaseTool(object):
 
         self.name_version = nvc_str(self.name, self.version)
 
-        self._init_logging()
+        self._init_logging(log_level)
 
-    def _init_logging(self):
+    def _init_logging(self, level="DEBUG"):
         """
         Initializes the logging parameters
         """
+        levels = {
+            "DEBUG": logging.DEBUG,
+            "INFO": logging.INFO,
+            "WARN": logging.WARNING,
+            "WARNING": logging.WARNING,
+            "ERROR": logging.ERROR,
+        }
+
         self.logger = logging.getLogger(f"{self.name_version}")
-        self.logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
 
         formatter = logging.Formatter(
             fmt="%(asctime)s - %(levelname)s:  %(message)s",
@@ -88,6 +98,7 @@ class BaseTool(object):
         filehandler.setFormatter(formatter)
 
         self.logger.addHandler(filehandler)
+        self.logger.setLevel(levels[os.environ.get("LOG_LEVEL", level)])
 
     def _run_command(self, command: str, expected_output: str) -> bool:
         """

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mussels",
-    version="0.2.1",
+    version="0.3.0",
     author="Micah Snyder",
     author_email="micasnyd@cisco.com",
-    copyright="Copyright (C) 2020 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
+    copyright="Copyright (C) 2021 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
     description="Mussels Dependency Build Automation Tool",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/tool_variables_test.py
+++ b/tests/tool_variables_test.py
@@ -1,0 +1,188 @@
+"""
+Copyright (C) 2021 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+Tests for versions.py utility functions
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import logging
+import multiprocessing
+import os
+import unittest
+import tempfile
+import shutil
+import sys
+import platform
+from pathlib import Path
+import http.server
+import socketserver
+from multiprocessing import Process, Pipe
+import tarfile
+import time
+
+import pytest
+
+from mussels.mussels import Mussels
+
+def execute_build(stdout, stderr):
+    sys.stdout = stdout.fileno()
+    sys.stderr = stderr.fileno()
+
+    my_mussels = Mussels(
+        install_dir=os.getcwd(),
+        work_dir=os.getcwd(),
+        log_dir=os.getcwd(),
+        download_dir=os.getcwd(),
+    )
+
+    results = []
+
+    success = my_mussels.build_recipe(
+        recipe="foobar",
+        version="",
+        cookbook="",
+        target="host",
+        results=results,
+        dry_run=False,
+        rebuild=False
+    )
+
+    stdout.send("The End")
+    stdout.close()
+    stderr.close()
+
+    if success == False:
+        sys.exit(1)
+
+    sys.exit(0)
+
+def host_server():
+    '''
+    Host files in the current directory on port 8000.
+    '''
+    PORT = 8000
+    Handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", PORT), Handler) as httpd:
+        print("serving at port", PORT)
+        httpd.serve_forever()
+
+
+class TC(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        TC.path_tmp = Path(tempfile.mkdtemp(prefix="msl-test-"))
+        TC.savedir = os.getcwd()
+        os.chdir(str(TC.path_tmp))
+
+        (TC.path_tmp / "foo.yaml").write_text(f'''
+name: python
+version: "3"
+mussels_version: "0.3"
+type: tool
+platforms:
+  Posix:
+    file_checks:
+      - {sys.executable}
+    variables:
+      foo: Hello World!
+  Windows:
+    file_checks:
+      - {sys.executable}
+    variables:
+      foo: Hello World!
+''')
+
+        # Make a foo.tar.gz package that the recipe build can download & extract.
+        (TC.path_tmp / 'foo').mkdir()
+        (TC.path_tmp / 'foo' / "foo.txt").write_text("Hello, World!\n")
+        with tarfile.open(str(TC.path_tmp / "foo.tar.gz"), "w:gz") as tar:
+            tar.add("foo")
+
+        TC.p = Process(target=host_server)
+        TC.p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        TC.p.terminate()
+        TC.p.kill()
+        os.chdir(TC.savedir)
+        shutil.rmtree(str(TC.path_tmp))
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_0_basic_variable(self):
+        (TC.path_tmp / "foobar.yaml").write_text('''
+name: foobar
+version: "1.2.3"
+url: https://www.example.com/foo.tar.gz
+mussels_version: "0.3"
+type: recipe
+platforms:
+  Posix:
+    host:
+      build_script:
+        make: |
+          echo "{python.foo}"
+      dependencies: []
+      required_tools:
+        - python
+  Windows:
+    host:
+      build_script:
+        make: |
+          echo "{python.foo}"
+      dependencies: []
+      required_tools:
+        - python
+''')
+
+        my_mussels = Mussels(
+            install_dir=os.getcwd(),
+            work_dir=os.getcwd(),
+            log_dir=os.getcwd(),
+            download_dir=os.getcwd(),
+            log_level="DEBUG"
+        )
+
+        results = []
+
+        success = my_mussels.build_recipe(
+            recipe="foobar",
+            version="",
+            cookbook="",
+            target="host",
+            results=results,
+            dry_run=False,
+            rebuild=False
+        )
+
+        logging.shutdown()
+
+        # Find the foobar log
+        for i in os.listdir(str(TC.path_tmp)):
+            if (TC.path_tmp / i).is_file() and i.startswith('foobar-1.2.3'):
+                text = (TC.path_tmp / i).read_text()
+                break
+
+        print(f"Checking for 'Hello World!' in:\n\n{text}")
+
+        assert "Hello World!" in text
+
+if __name__ == "__main__":
+    pytest.main(args=["-v", os.path.abspath(__file__)])


### PR DESCRIPTION
There is no way to make a recipe which has strings in it that vary
depending on which version of a tool is being used.

This commit adds tool variables, which is an optional list of variables
you place under each "platform" in a tool YAML file.

This feature was requested for the clamav project so that recipes which
use cmake and visualstudio can support both visualstudio 2017+ while
specifying the CMake generator string for the specific version of Visual
Studio.

Eg: "-G Visual Studio 15 2017" can now be evaluated from:
    "-G {visualstudio.cmake_generator}"

This clamav-mussels-cookbook PR makes use of this new feature:
 https://github.com/Cisco-Talos/clamav-mussels-cookbook/pull/13