### PR TITLE
Add setuptool as dependency and bump minor version (0.4.1)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.12
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.7
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.12
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
+## Version 0.4.1
+
+🐛 Fixed an issue using pkg_resources package when setuptools is not installed. The fix adds setuptools as a dependency.
+
 ## Version 0.4.0
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mussels",
-    version="0.4.0",
+    version="0.4.1",
     author="Micah Snyder",
     author_email="micasnyd@cisco.com",
-    copyright="Copyright (C) 2023 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
+    copyright="Copyright (C) 2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
     description="Mussels Dependency Build Automation Tool",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "patch",
         "gitpython",
         "pyyaml",
+        "setuptools",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Add setuptools to install_requires to fix an issue where setuptools might not be installed.

Bump version to 0.4.1 to get this fix out right away. 