### PR TITLE
Remove deprecated pkg_resources dependency, bump version to 0.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
+## Version 0.4.2
+
+🐛 Remove dependency on deprecated pkg_resources package to ensure compatibility with future Python versions.
+
 ## Version 0.4.1
 
 🐛 Fixed an issue using pkg_resources package when setuptools is not installed. The fix adds setuptools as a dependency.

--- a/mussels/__main__.py
+++ b/mussels/__main__.py
@@ -38,8 +38,8 @@ import sys
 
 import click
 import coloredlogs
+import importlib.metadata
 
-import pkg_resources
 from mussels.mussels import Mussels
 from mussels.utils.click import MusselsModifier, ShortNames
 
@@ -59,7 +59,7 @@ from colorama import Fore, Back, Style
     + __doc__
     + Fore.GREEN
     + _description
-    + f"\nVersion {pkg_resources.get_distribution('mussels').version}\n"
+    + f"\nVersion {importlib.metadata.version('mussels')}\n"
     + Style.RESET_ALL
     + _copyright,
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mussels",
-    version="0.4.1",
+    version="0.4.2",
     author="Micah Snyder",
     author_email="micasnyd@cisco.com",
     copyright="Copyright (C) 2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",


### PR DESCRIPTION
Use of pkg_resources is deprecated in favor of importlib.metadata.

Fix deprecation warning and ensure compatibility with newer Python versions.