### PR TITLE
Fix tool command detection and setup metadata

### DIFF
--- a/mussels/tool.py
+++ b/mussels/tool.py
@@ -100,11 +100,11 @@ class BaseTool(object):
         self.logger.addHandler(filehandler)
         self.logger.setLevel(levels[os.environ.get("LOG_LEVEL", level)])
 
-    def _run_command(self, command: str, expected_output: str) -> bool:
+    def _run_command(self, command: str, expected_output: str = "") -> bool:
         """
         Run a command.
         """
-        found_expected_output = False
+        found_expected_output = expected_output == ""
 
         cmd = command.split()
 
@@ -158,7 +158,7 @@ class BaseTool(object):
                     for script_check in self.platforms[each_platform]["command_checks"]:
                         found = self._run_command(
                             command=script_check["command"],
-                            expected_output=script_check["output_has"],
+                            expected_output=script_check.get("output_has", ""),
                         )
                         if not found:
                             self.logger.info(f"    {script_check['command']} failed.")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.4.2",
     author="Micah Snyder",
     author_email="micasnyd@cisco.com",
-    copyright="Copyright (C) 2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
+    license="Apache-2.0",
     description="Mussels Dependency Build Automation Tool",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -32,7 +32,6 @@ setuptools.setup(
     ],
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
 )

--- a/tests/tool_detect_test.py
+++ b/tests/tool_detect_test.py
@@ -1,0 +1,36 @@
+"""
+Regression tests for tool command detection behavior.
+"""
+
+import tempfile
+import unittest
+
+from mussels.tool import BaseTool
+
+
+class CommandCheckTool(BaseTool):
+    name = "command_check_tool"
+    version = "1.0"
+
+
+class ToolDetectTests(unittest.TestCase):
+    def test_detect_command_check_without_output_has(self):
+        tool = CommandCheckTool(data_dir=tempfile.mkdtemp(), log_level="DEBUG")
+        tool.platforms = {
+            "Posix": {
+                "command_checks": [
+                    {"command": "true"},
+                ]
+            }
+        }
+
+        self.assertTrue(tool.detect())
+
+    def test_run_command_accepts_empty_output_check_with_no_output(self):
+        tool = CommandCheckTool(data_dir=tempfile.mkdtemp(), log_level="DEBUG")
+
+        self.assertTrue(tool._run_command("true", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- allow command_checks without output_has
- treat empty output_has as exit-code-only success
- replace invalid setup.py copyright field with license metadata